### PR TITLE
Add SchemaFormEnum to Schema

### DIFF
--- a/src/schema.ts
+++ b/src/schema.ts
@@ -2,6 +2,7 @@ export type Schema =
   | SchemaFormEmpty
   | SchemaFormRef
   | SchemaFormType
+  | SchemaFormEnum
   | SchemaFormElements
   | SchemaFormProperties
   | SchemaFormValues


### PR DESCRIPTION
This PR fixes a bug in the current definition of `Schema`. One of the forms, namely the "enum" form, is mistakenly left out.