### PR TITLE
Run yarn build before publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,6 +20,7 @@ jobs:
       - run: yarn
       - run: yarn run test
       - run: echo "//registry.npmjs.org/:_authToken=${{ secrets.NODE_AUTH_TOKEN }}" > ~/.npmrc
+      - run: yarn run build
       - run: yarn publish
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NODE_AUTH_TOKEN }}


### PR DESCRIPTION
This PR attempts to fix the issue of blank builds being uploaded to NPM. That issue is suspected to be caused by not running `tsc` before publishing to the NPM registry.