### PR TITLE
Have tsc output commonjs modules

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,6 +5,7 @@
     "esModuleInterop": true,
     "moduleResolution": "node",
     "target": "es6",
+    "module": "commonjs",
     "rootDir": "src",
     "outDir": "lib"
   }


### PR DESCRIPTION
This PR has `tsc` output CJS modules. Otherwise, users crash on errors like:

```
export * from "./schema";
^^^^^^

SyntaxError: Unexpected token 'export'
```