### PR TITLE
Add .nojekyll to generated docs 

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -25,6 +25,7 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NODE_AUTH_TOKEN }}
       - run: yarn run typedoc
+      - run: touch docs/.nojekyll
       - uses: JamesIves/github-pages-deploy-action@releases/v3
         with:
           ACCESS_TOKEN: ${{ secrets.ACCESS_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jtd",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "description": "A JavaScript / TypeScript / Node.js implementation of JSON Type Definition",
   "main": "lib/index.js",
   "files": [


### PR DESCRIPTION
This PR adds .nojekyll to generated docs, to make Typedoc-generated files appear on GitHub pages. Otherwise, we run into the issue that GitHub Pages excludes underscore-prefixed files.