### PR TITLE
Trigger releases on GitHub releases

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,7 +1,7 @@
 on:
-  push:
-    branches:
-      - master
+  release:
+    types: [published]
+
 jobs:
   publish:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This PR changes the CI process to trigger NPM releases on GitHub releases, rather than master pushes. This unlocks the ability to merge PRs to master without having to do an NPM release simultaneously.