### PR TITLE
Fix name of secret containing NPM publish token

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,7 +21,7 @@ jobs:
       - run: npm run test
       - run: npm publish
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NODE_AUTH_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       - run: npx typedoc
       - run: touch docs/.nojekyll
       - uses: JamesIves/github-pages-deploy-action@releases/v3

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jtd",
-  "version": "0.1.0-test.1",
+  "version": "0.1.0-test.2",
   "description": "A JavaScript / TypeScript / Node.js implementation of JSON Type Definition",
   "main": "lib/index.js",
   "files": [


### PR DESCRIPTION
It turns out that a specific secret name must be used for the builtin setup system to do the right thing:

https://docs.github.com/en/actions/guides/publishing-nodejs-packages