### PR TITLE
Remove dependency on `moment`

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,5 @@
       "/lib"
     ]
   },
-  "dependencies": {
-    "moment": "^2.24.0"
-  }
+  "dependencies": {}
 }

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -57,22 +57,11 @@ describe("json-typedef-spec", () => {
       readFileSync("json-typedef-spec/tests/validation.json", "utf-8")
     );
 
-    // See comment in index.ts around why we skip this these particular timestamp
-    // test cases.
-    const SKIPPED_TESTS = [
-      "timestamp type schema - 1990-12-31T23:59:60Z",
-      "timestamp type schema - 1990-12-31T15:59:60-08:00"
-    ];
-
     for (const [name, { schema, instance, errors }] of Object.entries(
       testCases
     )) {
       it(name, () => {
         expect(isSchema(schema)).toBe(true);
-
-        if (SKIPPED_TESTS.includes(name)) {
-          return;
-        }
 
         if (isSchema(schema)) {
           expect(validate(schema, instance)).toEqual(errors);

--- a/src/rfc3339.test.ts
+++ b/src/rfc3339.test.ts
@@ -1,0 +1,42 @@
+
+import isRFC3339 from "./rfc3339"
+
+describe("isRFC3339", () => {
+  const testCases = {
+    // From the RFC
+    "1985-04-12T23:20:50.52Z": true,
+    "1990-12-31T23:59:60Z": true,
+    "1990-12-31T15:59:60-08:00": true,
+    "1937-01-01T12:00:27.87+00:20": true,
+
+    // T and Z can be t or z
+    "1985-04-12t23:20:50.52z": true,
+
+    // From http://henry.precheur.org/python/rfc3339
+    "2008-04-02T20:00:00Z": true,
+    "1970-01-01T00:00:00Z": true,
+
+    // https://github.com/chronotope/chrono/blob/main/src/format/parse.rs
+    "2015-01-20T17:35:20-08:00": true, // normal case
+    "1944-06-06T04:04:00Z": true, // D-day
+    "2001-09-11T09:45:00-08:00": true,
+    "2015-01-20T17:35:20.001-08:00": true,
+    "2015-01-20T17:35:20.000031-08:00": true,
+    "2015-01-20T17:35:20.000000004-08:00": true,
+    "2015-01-20T17:35:20.000000000452-08:00": true, // too small
+    "2015-02-30T17:35:20-08:00": false, // bad day of month
+    "2015-01-20T25:35:20-08:00": false, // bad hour
+    "2015-01-20T17:65:20-08:00": false, // bad minute
+    "2015-01-20T17:35:90-08:00": false, // bad second
+
+    // Ensure the regex is anchored
+    "x1985-04-12T23:20:50.52Zx": false,
+    "1985-04-12T23:20:50.52Zx": false,
+  }
+
+  for (const [s, expected] of Object.entries(testCases)) {
+    it(`correctly validates ${s}`, () => {
+      expect(isRFC3339(s)).toEqual(expected)
+    })
+  }
+})

--- a/src/rfc3339.ts
+++ b/src/rfc3339.ts
@@ -1,0 +1,66 @@
+const pattern = /^(\d{4})-(\d{2})-(\d{2})[tT](\d{2}):(\d{2}):(\d{2})(\.\d+)?([zZ]|((\+|-)(\d{2}):(\d{2})))$/
+
+export default function isRFC3339(s: string): boolean {
+  const matches = s.match(pattern);
+  if (matches === null) {
+    return false;
+  }
+
+  const year = parseInt(matches[1], 10);
+  const month = parseInt(matches[2], 10);
+  const day = parseInt(matches[3], 10);
+  const hour = parseInt(matches[4], 10);
+  const minute = parseInt(matches[5], 10);
+  const second = parseInt(matches[6], 10);
+
+  if (month > 12) {
+    return false;
+  }
+
+  if (day > maxDay(year, month)) {
+    return false;
+  }
+
+  if (hour > 23) {
+    return false;
+  }
+
+  if (minute > 59) {
+    return false;
+  }
+
+  // A value of 60 is permissible as a leap second.
+  if (second > 60) {
+    return false;
+  }
+
+  return true;
+}
+
+function maxDay(year: number, month: number) {
+  if (month === 2) {
+    return isLeapYear(year) ? 29 : 28;
+  }
+
+  return MONTH_LENGTHS[month];
+}
+
+function isLeapYear(n: number): boolean {
+  return n % 4 === 0 && (n % 100 !== 0 || n % 400 === 0);
+}
+
+const MONTH_LENGTHS = [
+  0, // months are 1-indexed, this is a dummy element
+  31,
+  0, // Feb is handled separately
+  31,
+  30,
+  31,
+  30,
+  31,
+  31,
+  30,
+  31,
+  30,
+  31,
+];

--- a/src/rfc3339.ts
+++ b/src/rfc3339.ts
@@ -1,3 +1,5 @@
+/** @ignore *//** */
+
 const pattern = /^(\d{4})-(\d{2})-(\d{2})[tT](\d{2}):(\d{2}):(\d{2})(\.\d+)?([zZ]|((\+|-)(\d{2}):(\d{2})))$/
 
 export default function isRFC3339(s: string): boolean {

--- a/src/validate.ts
+++ b/src/validate.ts
@@ -8,7 +8,7 @@
  * @packageDocumentation
  */
 
-import moment from "moment";
+import isRFC3339 from "./rfc3339";
 import {
   Schema,
   isRefForm,
@@ -210,16 +210,7 @@ function validateWithState(
         if (typeof instance !== "string") {
           pushError(state);
         } else {
-          // ISO 8601 is unfortunately not quite the same thing as RFC 3339.
-          // However, at the time of writing no adequate alternative,
-          // widely-used library for parsing RFC3339 timestamps exists.
-          //
-          // Notably, moment does not support two of the examples given in
-          // RFC 3339 with "60" in the seconds place. These timestamps arise
-          // due to leap seconds. See:
-          //
-          // https://tools.ietf.org/html/rfc3339#section-5.8
-          if (!moment(instance, moment.ISO_8601).isValid()) {
+          if (!isRFC3339(instance)) {
             pushError(state);
           }
         }


### PR DESCRIPTION
This PR removes any dependency on `moment`, bringing this package to have no external (non-dev) dependencies.